### PR TITLE
Add `shutdown` action to lifecycle of Tanok app

### DIFF
--- a/examples/4_subcomponent_collection/subcomponents.js
+++ b/examples/4_subcomponent_collection/subcomponents.js
@@ -18,6 +18,13 @@ export class Dashboard extends TanokDispatcher {
   init(payload, state) {
     return [state,
       subcomponentFx(COUNTERS_CHANGE, (new CounterDispatcher).collect()),
+      (stream) => {
+        const interval = setInterval(() => console.log('Demo of shutdown'), 1000);
+        stream.shutdownActions.push(() => {
+          console.log('Shutdown action');
+          clearInterval(interval)
+        });
+      }
     ]
   }
 

--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,7 @@ import Rx from 'rx';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import compose from './compose';
+import { INIT } from './coreActions';
 import { StreamWrapper, dispatch } from './streamWrapper.js';
 
 export const identity = (value) => value;
@@ -93,7 +94,7 @@ export function tanok(initialState, update, view, options) {
     console.error.bind(console)
   );
 
-  streamWrapper.send('init');
+  streamWrapper.send(INIT);
 
   component = ReactDOM.render(
     React.createElement(
@@ -108,9 +109,9 @@ export function tanok(initialState, update, view, options) {
     ),
     container
   )
-
+  let outerEventDisposable;
   if (outerEventStream) {
-    const outerEventDisposable = outerEventStream.subscribe(
+    outerEventDisposable = outerEventStream.subscribe(
       streamWrapper.stream.onNext.bind(streamWrapper.stream),
       console.error.bind(console)
     )
@@ -120,9 +121,10 @@ export function tanok(initialState, update, view, options) {
     disposable: streamWrapper.disposable,
     streamWrapper,
     shutdown: () => {
-        streamWrapper.disposable.dispose();
-        outerEventDisposable && outerEventDisposable.dispose();
-        ReactDOM.unmountComponentAtNode(container);
+      streamWrapper.onShutdown();
+      streamWrapper.disposable.dispose();
+      outerEventDisposable && outerEventDisposable.dispose();
+      ReactDOM.unmountComponentAtNode(container);
     },
     eventStream,
     component,

--- a/src/coreActions.js
+++ b/src/coreActions.js
@@ -1,0 +1,1 @@
+export const INIT = 'init';

--- a/src/streamWrapper.js
+++ b/src/streamWrapper.js
@@ -1,4 +1,5 @@
 import Rx from 'rx';
+import { INIT } from './coreActions';
 import { actionIs } from './helpers.js';
 
 const WRONG_UPDATE_HANDLER = 'Dispatcher must be subclass of TanokDispatcher or iterable';
@@ -58,6 +59,7 @@ export const StreamWrapper = function(stream, streamName) {
     this.streamName = streamName;
     this.disposable = null;
     this.metadata = [];
+    this.shutdownActions = [];
     this.subs = {};
     this.subsWithMeta = new WeakMap();
 }
@@ -85,7 +87,7 @@ StreamWrapper.prototype.subStream = function(subName, subUpdate) {
         console.error.bind(console)
       );
 
-    subStreamWrapper.send('init');
+    subStreamWrapper.send(INIT);
 
     return subStreamWrapper;
 };
@@ -117,4 +119,12 @@ StreamWrapper.prototype.subWithMeta = function(sub, metadata) {
 
   storage.set(key, mock);
   return mock;
+}
+
+
+StreamWrapper.prototype.onShutdown = function() {
+  Object.values(this.subs).forEach((subStream) => {
+    subStream.onShutdown();
+  });
+  this.shutdownActions.forEach((shutdownAction) => shutdownAction());
 }

--- a/src/tanokInReact.js
+++ b/src/tanokInReact.js
@@ -1,6 +1,7 @@
 import Rx from 'rx';
 import React from 'react';
 
+import { INIT } from './coreActions';
 import { StreamWrapper } from './streamWrapper.js';
 import { makeStreamState, streamWithEffects, identity } from './core.js';
 
@@ -47,6 +48,7 @@ export class TanokInReact extends React.Component {
     }
 
     this.shutdown = () => {
+      streamWrapper.onShutdown();
       streamWrapper.disposable.dispose();
       outerEventDisposable && outerEventDisposable.dispose();
     };
@@ -58,7 +60,7 @@ export class TanokInReact extends React.Component {
       state: initialState,
     };
 
-    streamWrapper.send('init');
+    streamWrapper.send(INIT);
   }
 
   componentDidMount() {


### PR DESCRIPTION
For cleanup intervals, internal streams, we should add `shutdown` action to lifecycle of our tanok App.